### PR TITLE
delete loose images on error

### DIFF
--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -1,10 +1,20 @@
 const winston = require("winston")
+const { Image } = require("../models/image")
 
-// Used as the last middleware function in routes.js this catches all errors thrown by 
+// Used as the last middleware function in applyMiddleware.js this catches all errors thrown by 
 // other middleware functions (mainly db connection issues)
-module.exports = function(err, req, res, next){
+module.exports = async function (err, req, res, next) {
     winston.error(err.message)
     res.status(500).send("Something failed")
-    //TODO: delete images found in req.imageIds
+
+    // Delete images if a request has saved images but then failed completing
+    if (req.imageIds) {
+        await Image.deleteMany({
+            _id: {
+                "$in": req.imageIds
+            }
+        })
+    }
+
     process.exit()
 }


### PR DESCRIPTION
If images have been saved with the current request, but it still fails, then the "loose" images wihtout any db relation are deleted again.