### PR TITLE
in user settings werden namen statt mailadressen angezeigt

### DIFF
--- a/client/src/components/User/User.jsx
+++ b/client/src/components/User/User.jsx
@@ -41,6 +41,20 @@ class User extends Component {
     };
 
     render() {
+
+
+        let loginName="";
+
+        if(this.state.email){
+            var loginNameArray = (this.state.email.substring(0, this.state.email.indexOf("@"))).split(".");
+
+            for (var i = 0; i < loginNameArray.length; i++) {
+                loginName += loginNameArray[i].charAt(0).toUpperCase() + loginNameArray[i].slice(1) + " ";
+            }
+        }
+
+
+
         return (
             <div className="user-item row">
                 {!this.state.clicked ? (
@@ -51,7 +65,7 @@ class User extends Component {
                                     <button className="accept" onClick={() => this.handlePromote()} title="Promote to admin"><i className="fas fa-plus"></i></button>
                                 </div>
                                 <div className="col-11 user-name">
-                                    <p>{this.state.email}</p>{" "}
+                                    <p>{loginName}</p>{" "}
                                 </div>
                             </div>
                         ) : (
@@ -60,7 +74,7 @@ class User extends Component {
                                     <button className="decline" onClick={() => this.handlePromote()} title="Downgrade to regular user"><i className="fas fa-times"></i></button>
                                 </div>
                                 <div className="col-11 user-name">
-                                    <p>{this.state.email}</p>{" "}
+                                    <p>{loginName}</p>{" "}
                                 </div>
                             </div>
                         )}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -371,6 +371,9 @@ button.add{
   }
 }
 
+.user-name{
+  padding: 20px 15px 20px 0;
+}
 
 .feature-text .comment-count p{
   margin: 0;


### PR DESCRIPTION
Da die mailadressen von thinkproject in "vorname.nachname" aufgeschlüsselt sind, können wir richtige namen darstellen, ohne usernames zu speichern.