### PR TITLE
show names instead of email-address

### DIFF
--- a/client/src/components/Comment/Comment.js
+++ b/client/src/components/Comment/Comment.js
@@ -62,18 +62,6 @@ class Comment extends Component{
             author: "Anonymous"
         })
     };
-
-    if(this.state.author.includes("@")){
-        var loginName="";
-        var loginNameArray = (this.state.author.substring(0, this.state.author.indexOf("@"))).split(".");
-
-        for (var i = 0; i < loginNameArray.length; i++) {
-            loginName += loginNameArray[i].charAt(0).toUpperCase() + loginNameArray[i].slice(1) + " ";
-        }
-        this.setState({
-            author: loginName
-        } );
-    }
     // console.log(this.state);
     }
 

--- a/client/src/components/Comment/Comment.js
+++ b/client/src/components/Comment/Comment.js
@@ -62,6 +62,18 @@ class Comment extends Component{
             author: "Anonymous"
         })
     };
+
+    if(this.state.author.includes("@")){
+        var loginName="";
+        var loginNameArray = (this.state.author.substring(0, this.state.author.indexOf("@"))).split(".");
+
+        for (var i = 0; i < loginNameArray.length; i++) {
+            loginName += loginNameArray[i].charAt(0).toUpperCase() + loginNameArray[i].slice(1) + " ";
+        }
+        this.setState({
+            author: loginName
+        } );
+    }
     // console.log(this.state);
     }
 

--- a/client/src/components/CommentForm.js
+++ b/client/src/components/CommentForm.js
@@ -21,8 +21,24 @@ class CommentForm extends Component {
             role: this.props.role,
             email: this.props.email,
             empty : true,
-            error : false
+            error : false,
         };
+    }
+
+
+
+    componentDidMount () {
+        if(this.state.role === "admin" || this.state.role === "employee"){
+            var loginName="";
+            var loginNameArray = (this.state.email.substring(0, this.state.email.indexOf("@"))).split(".");
+
+            for (var i = 0; i < loginNameArray.length; i++) {
+                loginName += loginNameArray[i].charAt(0).toUpperCase() + loginNameArray[i].slice(1) + " ";
+            }
+            this.setState({
+                name: loginName
+            } );
+        }
     }
 
     handleResponseButton = () => {
@@ -169,13 +185,10 @@ class CommentForm extends Component {
 
         const imageUrls = await this.uploadImage()
 
-        var name = ""
-        if(this.state.role === "admin" || this.state.role === "employee"){
-            name = this.state.email
-        }
-        else{
-            name = this.state.name.trim()
-        }
+        var name = "";
+
+        name = this.state.name.trim();
+
 
 
         let data = JSON.stringify({
@@ -205,6 +218,7 @@ class CommentForm extends Component {
     render() {
         const { name, content } = this.state;
 
+
         return (
 
             <div className="feature-form-container row col-12">
@@ -227,7 +241,8 @@ class CommentForm extends Component {
                         </div>
                         :
                             <div className="col-6 name">
-                            <p>{this.state.email}</p>
+                                <label>Name: </label>
+                                <p class="login-name">{this.state.name}</p>
                             </div>
                         }
                         

--- a/client/src/components/User/User.jsx
+++ b/client/src/components/User/User.jsx
@@ -7,11 +7,26 @@ class User extends Component {
         this.state = {
             email: this.props.email,
             newRole: this.props.newRole,
-            clicked: false
+            clicked: false,
+            name : "",
         };
 
         this.handlePromote = this.handlePromote.bind(this);
     }
+
+    componentDidMount () {
+        var loginName="";
+        var loginNameArray = (this.state.email.substring(0, this.state.email.indexOf("@"))).split(".");
+
+        for (var i = 0; i < loginNameArray.length; i++) {
+            loginName += loginNameArray[i].charAt(0).toUpperCase() + loginNameArray[i].slice(1) + " ";
+        }
+        this.setState({
+            name: loginName
+        } );
+    }
+
+
     handlePromote = () => {
         var self = this;
         const role = this.state.newRole;
@@ -45,13 +60,13 @@ class User extends Component {
             <div className="user-item row">
                 {!this.state.clicked ? (
                     <div>
-                        {this.props.newRole == "admin" ? (
+                        {this.props.newRole === "admin" ? (
                             <div>
                                 <div className="col-1 add-button">
                                     <button className="accept" onClick={() => this.handlePromote()} title="Promote to admin"><i className="fas fa-plus"></i></button>
                                 </div>
                                 <div className="col-11 user-name">
-                                    <p>{this.state.email}</p>{" "}
+                                    <p>{this.state.name}</p>{" "}
                                 </div>
                             </div>
                         ) : (
@@ -60,7 +75,7 @@ class User extends Component {
                                     <button className="decline" onClick={() => this.handlePromote()} title="Downgrade to regular user"><i className="fas fa-times"></i></button>
                                 </div>
                                 <div className="col-11 user-name">
-                                    <p>{this.state.email}</p>{" "}
+                                    <p>{this.state.name}</p>{" "}
                                 </div>
                             </div>
                         )}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -530,7 +530,10 @@ footer div{
 
 label{
   font-size: 1rem;
+}
 
+.login-name{
+  color: #7f9da7;
 }
 
 input, textarea{

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -435,6 +435,9 @@ button.search:hover, button.search:active{
 
 }
 
+.user-name{
+  padding: 20px 30px;
+}
 
 .feature-text .comment-count p{
   margin: 0;
@@ -701,5 +704,9 @@ select{
 
   .submit{
     margin-left: 15px;
+  }
+
+  .user-name{
+    padding: 20px 0;
   }
 }


### PR DESCRIPTION
Anstatt Mails werden jetzt Namen weitergegeben bei den Comments

In der User Settings Seite werden Namen statt Mails angezeigt.