### PR TITLE
weißer hintergrund für durchsichtige bilder

### DIFF
--- a/client/src/components/css/carousel.css
+++ b/client/src/components/css/carousel.css
@@ -212,7 +212,7 @@
     margin: 0;
     position: relative;
     text-align: center;
-    background: #000
+    background: #fff
 }
 
 .carousel .slide img {


### PR DESCRIPTION
Sieht sonst in der FDV manchmal kacke aus. (Bei denm Logos von den Showtime Projekten z.B.)